### PR TITLE
[RFR] Increase scoring in getMoveScore function

### DIFF
--- a/src/player/computer.js
+++ b/src/player/computer.js
@@ -43,7 +43,7 @@ export function getMoveScore(move, snake, apple, grid, tick) {
             return 0;
         }
 
-        return (1 / tick) * 10;
+        return (1 / tick) * 100;
     }
 
     return 1;


### PR DESCRIPTION
`isCollide` condition is not necessary because collides are already checked in `getPossibleMoves` function.
